### PR TITLE
'Use @types/node 16.x'

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,10 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/" # Location of package manifests
+  - package-ecosystem: 'npm'
+    directory: '/' # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: 'daily'
+    ignore:
+      - dependency-name: '@types/node'
+        versions: ['17.x']

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@types/jest": "^27.4.1",
-        "@types/node": "^17.0.21",
+        "@types/node": "^16.11.26",
         "@types/yargs": "^17.0.9",
         "jest": "^27.5.1",
         "rimraf": "^3.0.2",
@@ -1869,9 +1869,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "17.0.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
+      "version": "16.11.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
+      "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -7023,9 +7023,9 @@
       }
     },
     "@types/node": {
-      "version": "17.0.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
+      "version": "16.11.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
+      "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==",
       "dev": true
     },
     "@types/prettier": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",
-    "@types/node": "^17.0.21",
+    "@types/node": "^16.11.26",
     "@types/yargs": "^17.0.9",
     "jest": "^27.5.1",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
- Use @types/node 16.x
- Ignore @types/node 17.x in dependabot
